### PR TITLE
Denominator locks when being dragged too low

### DIFF
--- a/FractionVisualiser/FractionVisualiser.pde
+++ b/FractionVisualiser/FractionVisualiser.pde
@@ -5,8 +5,7 @@
 
 // These values are the ones that can be safely changed without breaking the program. Leave the variable names alone - just change the values
 color shadedFill=color(128,128,255);  // the fill colour (RGB) for shape sections that are "selected" by the fraction
-color emptyFill=color(255);  // the fill colour (greyscale) for shape sections that are not "selected" by the fraction. White (255) is
-                             // strongly recommended here to avoid user confusion
+color backGround=color(250, 250, 250);  // the fill colour (RGB) for background and shape sections that are not "selected" by the fraction.
 int shapeType=0;  // shape being shown (0=circle, 1=square) - starts with the value assigned
 int numShapes=1;  // number of shapes to be displayed (1 or 2)
 int maxDenominator=12;  // The maximum number of pieces that each shape can be divided up into. Very high values for this make it hard to
@@ -27,7 +26,7 @@ int diameter;  //display diameter of the shape being drawn
 
 void setup(){
   size(initialWindowWidth,inititalWindowHeight);
-  background(255);
+  background(backGround);
   if (frame != null) {  // check for environment that allows window resizing
     frame.setResizable(true);
   }
@@ -41,7 +40,7 @@ void setup(){
 }
 
 void draw(){
-  background(255);  // wipe the screen clear
+  background(backGround);  // wipe the screen clear
   // detect for mouseover of the sliders (to indicate UI controls)
   setNumerator.hover(mouseX, mouseY);
   setDenominator.hover(mouseX, mouseY);
@@ -50,13 +49,13 @@ void draw(){
   setDenominator.ypos=int(height*0.9);
   setNumerator.ypos=int(height*0.1);
 
-  // set numerator slider to match the number of shapes
-  setNumerator.max=setDenominator.value*numShapes;
-  if (setNumerator.value>setNumerator.max) setNumerator.value=setNumerator.max;    
-
   // check for user adjustment of fraction values
-  if (setNumerator.dragging) setNumerator.drag();
   if (setDenominator.dragging) setDenominator.drag();
+  if (setNumerator.value>setDenominator.value*numShapes) setDenominator.value=setDenominator.value+1;  // to stop the fraction exceeding the available number of shapes on the screen
+  if (setNumerator.dragging) setNumerator.drag();
+
+  // set numerator slider to match the maximum available (set by denominator and number of shapes)
+  setNumerator.max=setDenominator.value*numShapes;
   
   // display sliders and shape selector (as these are always displayed)
   setDenominator.display();

--- a/FractionVisualiser/Rectangle.pde
+++ b/FractionVisualiser/Rectangle.pde
@@ -21,12 +21,12 @@ class Rectangle{
         translate(xpos,ypos);
         rotate(angle);
       if (setDenominator.value==1){
-        if (numerator==0) fill(emptyFill);
+        if (numerator==0) fill(backGround);
         rect(0, 0, sideLength, sideLength);
       }
       else{
         for(int i=0; i<setDenominator.value; i++){
-          if(i==numerator) fill(emptyFill);  //switch to "empty" segments
+          if(i==numerator) fill(backGround);  //switch to "empty" segments
           rect(0, (-0.5*sideLength)+(i+0.5)*(sideLength/denominator), sideLength, sideLength/denominator);          
         }
       } 

--- a/FractionVisualiser/Slider.pde
+++ b/FractionVisualiser/Slider.pde
@@ -1,7 +1,7 @@
 class Slider{
  
- int max;  // maximum value
- int min;  // minimum value
+ int max;  // maximum on the slider line
+ int min;  // minimum value on the slider line
  int value;  // current value
  int xpos;  // x-coordinate of the selection ball
  int ypos;  // y-coordinate of the line and selection ball

--- a/FractionVisualiser/Wheel.pde
+++ b/FractionVisualiser/Wheel.pde
@@ -21,13 +21,13 @@ class Wheel{
     fill(shadedFill);  // start with filled segments
     
     if (denominator==1){
-      if (numerator==0) fill(emptyFill);
+      if (numerator==0) fill(backGround);
       ellipse(xpos, ypos, diameter, diameter);
     }
     else{
       for(int i=0; i<denominator; i++){
         if (angle>(2*PI)) angle=angle-(2*PI);  //reset angle once over 2*PI
-        if(i==numerator) fill(emptyFill);  //switch to "empty" segments
+        if(i==numerator) fill(backGround);  //switch to "empty" segments
      
         arc(xpos, ypos, diameter, diameter, angle, angle+(2*PI/denominator), PIE);
         angle=angle+(2*PI)/denominator;


### PR DESCRIPTION
also cleaned up the background colour specification to match the
unselected shaped rather than hard-coded white.
